### PR TITLE
Allow dalliance models to specify a reprocessing method

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -24,7 +24,7 @@ needing to loop in PMs or developers:
 
     class Model < ActiveRecord::Base
       dalliance :process_method,
-                dalliance_reprocess_method: :reprocessing_method
+                reprocess_method: :reprocessing_method
     end
 
 Keep in mind that a record that has not already been completely processed (eg in

--- a/README.rdoc
+++ b/README.rdoc
@@ -19,7 +19,19 @@ In your model:
 process_method is the name of the method to invoke for background processing
 to kick it off just call dalliance_background_process
 
-Handle your migrations:
+Models can also be re-processed to allow front-end users to reprocess without
+needing to loop in PMs or developers:
+
+    class Model < ActiveRecord::Base
+      dalliance :process_method,
+                dalliance_reprocess_method: :reprocessing_method
+    end
+
+Keep in mind that a record that has not already been completely processed (eg in
+a state of 'pending' or 'processing') cannot be reprocessed. Attempting to
+reprocess the record will raise an error.
+
+== Handle your migrations:
 
    rails g dalliance:progress_meter
 

--- a/lib/dalliance.rb
+++ b/lib/dalliance.rb
@@ -245,7 +245,7 @@ module Dalliance
     reprocess_dalliance!
 
     do_dalliance_process(
-      perform_method: self.class.dalliance_options[:dalliance_reprocess_method],
+      perform_method: self.class.dalliance_options[:reprocess_method],
       background_processing: background_processing
     )
   end
@@ -346,7 +346,7 @@ module Dalliance
       #   the name of the method to call when processing the model in dalliance
       # @param [Hash] options
       #   an optional hash of options for dalliance processing
-      # @option options [Symbol] :dalliance_reprocess_method
+      # @option options [Symbol] :reprocess_method
       #   the name of the method to use to reprocess the model in dalliance
       # @option options [Boolean] :dalliance_process_meter
       #   whether or not to display a progress meter

--- a/lib/dalliance.rb
+++ b/lib/dalliance.rb
@@ -118,6 +118,10 @@ module Dalliance
       event :finish_dalliance do
         transition :processing => :completed
       end
+
+      event :reprocess_dalliance do
+        transition [:validation_error, :processing_error, :completed] => :pending
+      end
     end
     #END state_machine(s)
 
@@ -213,17 +217,40 @@ module Dalliance
     end
   end
 
-  #Force backgound_processing w/ true
-  def dalliance_background_process(backgound_processing = nil)
-    if backgound_processing || (backgound_processing.nil? && self.class.dalliance_options[:background_processing])
-      self.class.dalliance_options[:worker_class].enqueue(self, processing_queue)
+  #Force background_processing w/ true
+  def dalliance_background_process(background_processing = nil)
+    if background_processing || (background_processing.nil? && self.class.dalliance_options[:background_processing])
+      self.class.dalliance_options[:worker_class].enqueue(self, processing_queue, :dalliance_process)
     else
       dalliance_process(false)
     end
   end
 
-  #backgound_processing == false will re-raise any exceptions
-  def dalliance_process(backgound_processing = false)
+  def dalliance_process(background_processing = false)
+    do_dalliance_process(
+      perform_method: self.class.dalliance_options[:dalliance_method],
+      background_processing: background_processing
+    )
+  end
+
+  def dalliance_background_reprocess(background_processing = nil)
+    if background_processing || (background_processing.nil? && self.class.dalliance_options[:background_processing])
+      self.class.dalliance_options[:worker_class].enqueue(self, processing_queue, :dalliance_reprocess)
+    else
+      dalliance_reprocess(false)
+    end
+  end
+
+  def dalliance_reprocess(background_processing = false)
+    reprocess_dalliance!
+
+    do_dalliance_process(
+      perform_method: self.class.dalliance_options[:dalliance_reprocess_method],
+      background_processing: background_processing
+    )
+  end
+
+  def do_dalliance_process(perform_method:, background_processing: false)
     start_time = Time.now
 
     begin
@@ -233,7 +260,7 @@ module Dalliance
         build_dalliance_progress_meter(:total_count => calculate_dalliance_progress_meter_total_count).save!
       end
 
-      self.send(self.class.dalliance_options[:dalliance_method])
+      self.send(perform_method)
 
       finish_dalliance! unless validation_error?
     rescue StandardError => e
@@ -261,8 +288,8 @@ module Dalliance
 
       error_notifier.call(e)
 
-      #Don't raise the error if we're backgound_processing...
-      raise e unless backgound_processing && self.class.dalliance_options[:worker_class].rescue_error?
+      # Don't raise the error if we're background processing...
+      raise e unless background_processing && self.class.dalliance_options[:worker_class].rescue_error?
     ensure
       if self.class.dalliance_options[:dalliance_progress_meter] && dalliance_progress_meter
         #Works with optimistic locking...
@@ -313,15 +340,28 @@ module Dalliance
     end
 
     module ClassMethods
-      def dalliance(*args)
-        options = args.last.is_a?(Hash) ? Dalliance.options.merge(args.pop) : Dalliance.options
+      # Enables dalliance processing for this class.
+      #
+      # @param [Symbol|String] dalliance_method
+      #   the name of the method to call when processing the model in dalliance
+      # @param [Hash] options
+      #   an optional hash of options for dalliance processing
+      # @option options [Symbol] :dalliance_reprocess_method
+      #   the name of the method to use to reprocess the model in dalliance
+      # @option options [Boolean] :dalliance_process_meter
+      #   whether or not to display a progress meter
+      # @option options [String] :queue
+      #   the name of the worker queue to use. Default 'dalliance'
+      # @option options [String] :duration_column
+      #   the name of the table column that stores the dalliance processing time. Default 'dalliance_duration'
+      # @option options [Object] :logger
+      #   the logger object to use. Can be nil
+      # @option options [Proc] :error_notifier
+      #   A proc that accepts an error object. Default is a NOP
+      def dalliance(dalliance_method, options = {})
+        opts = Dalliance.options.merge(options)
 
-        case args.length
-        when 1
-          options[:dalliance_method] = args[0]
-        else
-          raise ArgumentError, "Incorrect number of Arguements provided"
-        end
+        opts[:dalliance_method] = dalliance_method
 
         if dalliance_options.nil?
           self.dalliance_options = {}
@@ -329,7 +369,7 @@ module Dalliance
           self.dalliance_options = self.dalliance_options.dup
         end
 
-        self.dalliance_options.merge!(options)
+        self.dalliance_options.merge!(opts)
 
         include Dalliance
       end

--- a/lib/dalliance.rb
+++ b/lib/dalliance.rb
@@ -301,8 +301,11 @@ module Dalliance
 
       dalliance_log("[dalliance] #{self.class.name}(#{id}) - #{dalliance_status} #{duration.to_i}")
 
-      if self.class.dalliance_options[:duration_column]
-        self.class.where(id: self.id).update_all(self.class.dalliance_options[:duration_column] => duration.to_i)
+      duration_column = self.class.dalliance_options[:duration_column]
+      if duration_column.present?
+        current_duration = self.send(duration_column) || 0
+        self.class.where(id: self.id)
+          .update_all(duration_column => current_duration + duration.to_f)
       end
     end
   end

--- a/spec/dalliance/asynchronous_delayed_job_spec.rb
+++ b/spec/dalliance/asynchronous_delayed_job_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe DallianceModel do
 
       before do
         subject.dalliance_process
+        subject.reload
       end
 
       it 'successfully runs the dalliance_reprocess method' do
@@ -95,6 +96,15 @@ RSpec.describe DallianceModel do
         expect(subject).to be_successful
         expect(Delayed::Job.count).to eq(0)
         expect(subject.reprocessed_count).to eq(1)
+      end
+
+      it 'increases the total processing time counter' do
+        original_duration = subject.dalliance_duration
+        subject.dalliance_background_reprocess
+        Delayed::Worker.new(:queues => [:dalliance]).work_off
+        subject.reload
+
+        expect(subject.dalliance_duration).to be_between(original_duration, Float::INFINITY)
       end
     end
 

--- a/spec/dalliance/asynchronous_delayed_job_spec.rb
+++ b/spec/dalliance/asynchronous_delayed_job_spec.rb
@@ -77,6 +77,27 @@ RSpec.describe DallianceModel do
       expect(subject.dalliance_duration).not_to eq(nil)
     end
 
+    context 'reprocess' do
+      before(:all) do
+        DallianceModel.dalliance_options[:worker_class] = Dalliance::Workers::DelayedJob
+        DallianceModel.dalliance_options[:queue] = 'dalliance'
+      end
+
+      before do
+        subject.dalliance_process
+      end
+
+      it 'successfully runs the dalliance_reprocess method' do
+        subject.dalliance_background_reprocess
+        Delayed::Worker.new(:queues => [:dalliance]).work_off
+        subject.reload
+
+        expect(subject).to be_successful
+        expect(Delayed::Job.count).to eq(0)
+        expect(subject.reprocessed_count).to eq(1)
+      end
+    end
+
     context "another_queue" do
       let(:queue) { 'dalliance_2'}
 

--- a/spec/dalliance/asynchronous_resque_spec.rb
+++ b/spec/dalliance/asynchronous_resque_spec.rb
@@ -114,6 +114,34 @@ RSpec.describe DallianceModel do
     end
   end
 
+  context 'reprocess' do
+    before :all do
+      DallianceModel.dalliance_options[:worker_class] = Dalliance::Workers::Resque
+      DallianceModel.dalliance_options[:queue] = 'dalliance'
+    end
+
+    before do
+      subject.dalliance_process
+    end
+
+    it 'successfully runs the dalliance_reprocess method' do
+      Resque::Stat.clear(:processed)
+      Resque::Stat.clear(:failed)
+
+      subject.dalliance_background_reprocess
+      Resque::Worker.new(:dalliance).process
+      subject.reload
+
+      aggregate_failures do
+        expect(subject).to be_successful
+        expect(Resque.size(:dalliance)).to eq(0)
+        expect(Resque::Stat[:processed]).to eq(1)
+        expect(Resque::Stat[:failed]).to eq(0)
+        expect(subject.reprocessed_count).to eq(1)
+      end
+    end
+  end
+
   context "raise error" do
     before(:all) do
       DallianceModel.dalliance_options[:dalliance_method] = :dalliance_error_method

--- a/spec/dalliance/asynchronous_resque_spec.rb
+++ b/spec/dalliance/asynchronous_resque_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe DallianceModel do
 
     before do
       subject.dalliance_process
+      subject.reload
     end
 
     it 'successfully runs the dalliance_reprocess method' do
@@ -139,6 +140,15 @@ RSpec.describe DallianceModel do
         expect(Resque::Stat[:failed]).to eq(0)
         expect(subject.reprocessed_count).to eq(1)
       end
+    end
+
+    it 'increases the total processing time counter' do
+      original_duration = subject.dalliance_duration
+      subject.dalliance_background_reprocess
+      Delayed::Worker.new(:queues => [:dalliance]).work_off
+      subject.reload
+
+      expect(subject.dalliance_duration).to be_between(original_duration, Float::INFINITY)
     end
   end
 

--- a/spec/dalliance/synchronous_spec.rb
+++ b/spec/dalliance/synchronous_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe DallianceModel do
     context 'when the model has already processed' do
       before do
         subject.dalliance_background_process
+        subject.reload
       end
 
       it 'calls the dalliance_reprocess method' do
@@ -75,6 +76,15 @@ RSpec.describe DallianceModel do
         expect { subject.dalliance_background_reprocess }
           .not_to change { subject.reload.dalliance_progress }
           .from(100)
+      end
+
+      it 'increases the total processing time counter' do
+        original_duration = subject.dalliance_duration
+        subject.dalliance_background_reprocess
+        Delayed::Worker.new(:queues => [:dalliance]).work_off
+        subject.reload
+
+        expect(subject.dalliance_duration).to be_between(original_duration, Float::INFINITY)
       end
     end
   end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define do
     t.integer :dalliance_duration
 
     t.boolean :successful, :default => false
+    t.integer :reprocessed_count, default: 0
   end
 end
 
@@ -47,10 +48,15 @@ class DallianceModel < ActiveRecord::Base
   include Dalliance::Glue
 
   dalliance :dalliance_success_method,
+            dalliance_reprocess_method: :dalliance_reprocess_method,
             :logger => nil
 
   def dalliance_success_method
     update_attribute(:successful, true)
+  end
+
+  def dalliance_reprocess_method
+    update_attribute(:reprocessed_count, self.reprocessed_count + 1)
   end
 
   def dalliance_error_method

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define do
   create_table :dalliance_models, :force => true do |t|
     t.text    :dalliance_error_hash
     t.string  :dalliance_status, :string, :null => false, :default => 'pending'
-    t.integer :dalliance_duration
+    t.decimal :dalliance_duration
 
     t.boolean :successful, :default => false
     t.integer :reprocessed_count, default: 0

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -48,7 +48,7 @@ class DallianceModel < ActiveRecord::Base
   include Dalliance::Glue
 
   dalliance :dalliance_success_method,
-            dalliance_reprocess_method: :dalliance_reprocess_method,
+            reprocess_method: :dalliance_reprocess_method,
             :logger => nil
 
   def dalliance_success_method


### PR DESCRIPTION
This lets models define how they can be reprocessed if there was an error or non-exceptional issue when the model was first processed.
Pending and currently processing models cannot be reprocessed

Usage:
```ruby
dalliance :main_processing_method,
          dalliance_reprocessing_method: :custom_reprocessing_method
```

Call like:

```ruby
my_model.dalliance_reprocess # Synchronous reprocessing
my_model.dalliance_background_reprocess # Asynchronous reprocessing
```