### PR TITLE
Allow dalliance records to be cancelled when pending or processing

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
           validation_error: Validation Error
           processing_error: Processing Error
           completed: Completed
+          cancelled: Cancelled
   attributes:
     dalliance_status: Status
     dalliance_error_hash: Errors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
           validation_error: Validation Error
           processing_error: Processing Error
           completed: Completed
+          cancel_requested: Cancellation Requested
           cancelled: Cancelled
   attributes:
     dalliance_status: Status

--- a/lib/dalliance.rb
+++ b/lib/dalliance.rb
@@ -91,6 +91,7 @@ module Dalliance
     scope :validation_error, -> { where(:dalliance_status => 'validation_error') }
     scope :processing_error, -> { where(:dalliance_status => 'processing_error') }
     scope :completed, -> { where(:dalliance_status => 'completed') }
+    scope :cancel_requested, -> { where(:dalliance_status => 'cancel_requested') }
     scope :cancelled, -> { where(:dalliance_status => 'cancelled') }
 
     state_machine :dalliance_status, :initial => :pending do

--- a/lib/dalliance.rb
+++ b/lib/dalliance.rb
@@ -205,7 +205,7 @@ module Dalliance
 
   def validate_dalliance_status
     unless error_or_completed? || cancelled?
-      errors.add(:dalliance_status, :invalid)
+      errors.add(:dalliance_status, "Processing must be finished or cancelled, but status is '#{dalliance_status}'")
       if defined?(Rails)
         throw(:abort)
       else

--- a/lib/dalliance.rb
+++ b/lib/dalliance.rb
@@ -204,7 +204,7 @@ module Dalliance
   end
 
   def validate_dalliance_status
-    unless error_or_completed?
+    unless error_or_completed? || cancelled?
       errors.add(:dalliance_status, :invalid)
       if defined?(Rails)
         throw(:abort)

--- a/lib/dalliance.rb
+++ b/lib/dalliance.rb
@@ -278,7 +278,7 @@ module Dalliance
 
       self.send(perform_method)
 
-      finish_dalliance! unless validation_error?
+      finish_dalliance! unless validation_error? || cancelled?
     rescue StandardError => e
       #Save the error for future analysis...
       self.dalliance_error_hash = {:error => e.class.name, :message => e.message, :backtrace => e.backtrace}

--- a/lib/dalliance.rb
+++ b/lib/dalliance.rb
@@ -200,7 +200,7 @@ module Dalliance
   end
 
   def error_or_completed?
-    validation_error? || processing_error? || completed?
+    validation_error? || processing_error? || completed? || cancelled?
   end
 
   # Cancels the job and removes it from the queue if has not already been taken
@@ -223,7 +223,7 @@ module Dalliance
   end
 
   def validate_dalliance_status
-    unless error_or_completed? || cancelled?
+    unless error_or_completed?
       errors.add(:dalliance_status, "Processing must be finished or cancelled, but status is '#{dalliance_status}'")
       if defined?(Rails)
         throw(:abort)

--- a/lib/dalliance/workers/delayed_job.rb
+++ b/lib/dalliance/workers/delayed_job.rb
@@ -10,6 +10,10 @@ module Dalliance
             .perform_later(instance.class.name, instance.id, perform_method.to_s)
         end
 
+        def self.dequeue(_instance)
+          # NOP
+        end
+
         def perform(instance_klass, instance_id, perform_method)
           instance_klass
             .constantize
@@ -29,6 +33,10 @@ module Dalliance
             self.new(instance.class.name, instance.id, perform_method),
             :queue => queue
           )
+        end
+
+        def self.dequeue(_instance)
+          # NOP
         end
 
         def perform

--- a/spec/dalliance/asynchronous_resque_spec.rb
+++ b/spec/dalliance/asynchronous_resque_spec.rb
@@ -184,12 +184,19 @@ RSpec.describe DallianceModel do
         .to('cancelled')
     end
 
-    # TODO: actually dequeue pending jobs when they're cancelled
-    #       The current implementation just quits the job immediately
-    it 'does not dequeue the job' do
-      subject.dalliance_background_process
-      expect { subject.cancel_dalliance! }
-        .not_to change { Resque.size('dalliance') }
+    it 'dequeues the job' do
+      expect { subject.dalliance_background_process }
+        .to change { Resque.size('dalliance') }
+        .from(0)
+        .to(1)
+
+      expect { subject.cancel_and_dequeue_dalliance! }
+        .to change { Resque.size('dalliance') }
+        .from(1)
+        .to(0)
+        .and change { subject.dalliance_status }
+        .from('pending')
+        .to('cancelled')
     end
 
     it 'does not process' do

--- a/spec/dalliance/asynchronous_resque_spec.rb
+++ b/spec/dalliance/asynchronous_resque_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DallianceModel do
 
   before do
     Resque.remove_queue(:dalliance)
+    Resque.remove_queue(:notaqueue)
   end
 
   context "no worker_class" do
@@ -165,6 +166,40 @@ RSpec.describe DallianceModel do
       Resque::Worker.new(:dalliance).process
 
       expect(subject).to be_successful
+    end
+  end
+
+  context 'cancelling' do
+    before(:all) do
+      DallianceModel.dalliance_options[:dalliance_method] = :dalliance_success_method
+      DallianceModel.dalliance_options[:worker_class] = Dalliance::Workers::Resque
+      DallianceModel.dalliance_options[:queue] = 'dalliance'
+    end
+
+    it 'can be cancelled after being queued' do
+      subject.dalliance_background_process
+      expect { subject.cancel_dalliance! }
+        .to change { subject.dalliance_status }
+        .from('pending')
+        .to('cancelled')
+    end
+
+    # TODO: actually dequeue pending jobs when they're cancelled
+    #       The current implementation just quits the job immediately
+    it 'does not dequeue the job' do
+      subject.dalliance_background_process
+      expect { subject.cancel_dalliance! }
+        .not_to change { Resque.size('dalliance') }
+    end
+
+    it 'does not process' do
+      subject.cancel_dalliance!
+      subject.dalliance_background_process
+
+      Resque::Worker.new(:dalliance).process
+      subject.reload
+
+      expect(subject.successful).to eq false
     end
   end
 

--- a/spec/dalliance/dalliance_spec.rb
+++ b/spec/dalliance/dalliance_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'Dalliance' do
         ["Processing", "processing"],
         ["Processing Error", "processing_error"],
         ["Validation Error", "validation_error"],
+        ["Cancellation Requested", "cancel_requested"],
         ['Cancelled', 'cancelled']
       )
     end

--- a/spec/dalliance/dalliance_spec.rb
+++ b/spec/dalliance/dalliance_spec.rb
@@ -9,13 +9,14 @@ RSpec.describe 'Dalliance' do
 
   context "self#dalliance_status_in_load_select_array" do
     it "should return [state, human_name]" do
-      expect(DallianceModel.dalliance_status_in_load_select_array).to eq([
+      expect(DallianceModel.dalliance_status_in_load_select_array).to contain_exactly(
         ["Completed", "completed"],
         ["Pending", "pending"],
         ["Processing", "processing"],
         ["Processing Error", "processing_error"],
-        ["Validation Error", "validation_error"]
-      ])
+        ["Validation Error", "validation_error"],
+        ['Cancelled', 'cancelled']
+      )
     end
   end
 

--- a/spec/dalliance/synchronous_spec.rb
+++ b/spec/dalliance/synchronous_spec.rb
@@ -180,13 +180,15 @@ RSpec.describe DallianceModel do
     it "should return false when pending?" do
       subject.update_column(:dalliance_status, 'pending')
       expect(subject.destroy).to be_falsey
-      expect(subject.errors[:dalliance_status]).to eq(['is invalid'])
+      expect(subject.errors[:dalliance_status])
+        .to eq(["Processing must be finished or cancelled, but status is 'pending'"])
     end
 
     it "should return false when processing?" do
       subject.update_column(:dalliance_status, 'processing')
       expect(subject.destroy).to be_falsey
-      expect(subject.errors[:dalliance_status]).to eq(['is invalid'])
+      expect(subject.errors[:dalliance_status])
+        .to eq(["Processing must be finished or cancelled, but status is 'processing'"])
     end
 
     it "should return true when validation_error?" do

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -59,6 +59,13 @@ class DallianceModel < ActiveRecord::Base
     update_attribute(:reprocessed_count, self.reprocessed_count + 1)
   end
 
+  # Pretends that an external action requested processing to be cancelled, but
+  # ignores the request and finishes anyway.
+  def dalliance_ignore_cancellation_method
+    request_cancel_dalliance!
+    update_attribute(:successful, true)
+  end
+
   def dalliance_error_method
     raise RuntimeError
   end


### PR DESCRIPTION
This implementation ONLY sets the dalliance status to 'cancelled'

Implementations are required to check this status while processing and implement their own cancellation logic

If a record is cancelled while it is still in a queue, it will remain in the queue and immediately exit with a NOP once taken by a worker. A job in a Resque queue can be removed manually via `Dalliance::Workers::Resque#deqeue`, or can be cancelled and dequeued at once via `cancel_and_dequeue_dalliance!` instead of the base `cancel_dalliance!`.  Removal from DelayedJob queues isn't supported.