### PR TITLE
Add convenience methods for checking if a dalliance record is queued

### DIFF
--- a/lib/dalliance.rb
+++ b/lib/dalliance.rb
@@ -256,6 +256,19 @@ module Dalliance
     end
   end
 
+  # Is a job queued to the given processing queue for this record?
+  #
+  # @param queue_name [String]
+  #   the name of the queue to check for jobs.  Defaults to the configured
+  #   processing queue
+  #
+  # @return [Boolean]
+  def queued?(queue_name: processing_queue)
+
+    worker_class = self.class.dalliance_options[:worker_class]
+    worker_class.queued?(self, queue_name)
+  end
+
   #Force background_processing w/ true
   def dalliance_background_process(background_processing = nil)
     if background_processing || (background_processing.nil? && self.class.dalliance_options[:background_processing])

--- a/lib/dalliance/workers/delayed_job.rb
+++ b/lib/dalliance/workers/delayed_job.rb
@@ -14,6 +14,18 @@ module Dalliance
           # NOP
         end
 
+        def self.queued?(instance, queue)
+          queued_jobs =
+            Delayed::Job.where(queue: queue)
+              .pluck(:handler)
+              .map(&YAML.method(:load))
+
+          queued_jobs.any? do |job_wrapper|
+            job_wrapper.job_data['arguments'].first(2) ==
+              [instance.class.name, instance.id]
+          end
+        end
+
         def perform(instance_klass, instance_id, perform_method)
           instance_klass
             .constantize
@@ -37,6 +49,18 @@ module Dalliance
 
         def self.dequeue(_instance)
           # NOP
+        end
+
+        def self.queued?(instance, queue)
+          queued_jobs =
+            Delayed::Job.where(queue: queue)
+              .pluck(:handler)
+              .map(&YAML.method(:load))
+
+          queued_jobs.any? do |job_wrapper|
+            job_wrapper.job_data['arguments'].first(2) ==
+              [instance.class.name, instance.id]
+          end
         end
 
         def perform

--- a/lib/dalliance/workers/resque.rb
+++ b/lib/dalliance/workers/resque.rb
@@ -27,6 +27,21 @@ module Dalliance
           end
         end
 
+        def self.queued?(instance, queue_name)
+          # All current jobs in the queue
+          queued_jobs =
+            ::Resque.redis.everything_in_queue(queue_name)
+              .map(&::Resque.method(:decode))
+
+          queued_jobs.any? do |job_info_hash|
+            job_info_hash
+              .fetch('args', [{}])
+              .first
+              .fetch('arguments', [])
+              .first(2) == [instance.class.name, instance.id]
+          end
+        end
+
         def perform(instance_klass, instance_id, perform_method)
           instance_klass
             .constantize
@@ -59,6 +74,21 @@ module Dalliance
                dalliance_args == [instance.class.name, instance.id, 'dalliance_reprocess']
               redis.remove_from_queue(queue, string)
             end
+          end
+        end
+
+        def self.queued?(instance, queue_name)
+          # All current jobs in the queue
+          queued_jobs =
+            ::Resque.redis.everything_in_queue(queue_name)
+              .map(&::Resque.method(:decode))
+
+          queued_jobs.any? do |job_info_hash|
+            job_info_hash
+              .fetch('args', [{}])
+              .first
+              .fetch('arguments', [])
+              .first(2) == [instance.class.name, instance.id]
           end
         end
 

--- a/lib/dalliance/workers/resque.rb
+++ b/lib/dalliance/workers/resque.rb
@@ -34,11 +34,14 @@ module Dalliance
               .map(&::Resque.method(:decode))
 
           queued_jobs.any? do |job_info_hash|
-            job_info_hash
-              .fetch('args', [{}])
-              .first
-              .fetch('arguments', [])
-              .first(2) == [instance.class.name, instance.id]
+            args = job_info_hash['args']
+            next unless args.is_a?(Array)
+
+            arg = args[0]
+            next unless arg.is_a?(Hash)
+
+            arg.fetch('arguments', []).first(2) ==
+              [instance.class.name, instance.id]
           end
         end
 
@@ -84,11 +87,14 @@ module Dalliance
               .map(&::Resque.method(:decode))
 
           queued_jobs.any? do |job_info_hash|
-            job_info_hash
-              .fetch('args', [{}])
-              .first
-              .fetch('arguments', [])
-              .first(2) == [instance.class.name, instance.id]
+            args = job_info_hash['args']
+            next unless args.is_a?(Array)
+
+            arg = args[0]
+            next unless arg.is_a?(Hash)
+
+            arg.fetch('arguments', []).first(2) ==
+              [instance.class.name, instance.id]
           end
         end
 

--- a/spec/dalliance/asynchronous_delayed_job_spec.rb
+++ b/spec/dalliance/asynchronous_delayed_job_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe DallianceModel do
 
     it "should call the dalliance_method w/ a Delayed::Worker" do
       subject.dalliance_background_process
+      expect(subject).to be_queued
       Delayed::Worker.new(:queues => [:dalliance]).work_off
       subject.reload
 
@@ -53,6 +54,7 @@ RSpec.describe DallianceModel do
 
     it "should set the dalliance_status to completed" do
       subject.dalliance_background_process
+      expect(subject).to be_queued
       Delayed::Worker.new(:queues => [:dalliance]).work_off
       subject.reload
 
@@ -61,6 +63,7 @@ RSpec.describe DallianceModel do
 
     it "should set the dalliance_progress to 100" do
       subject.dalliance_background_process
+      expect(subject).to be_queued
       Delayed::Worker.new(:queues => [:dalliance]).work_off
       subject.reload
 
@@ -71,6 +74,7 @@ RSpec.describe DallianceModel do
       expect(subject.dalliance_duration).to eq(nil)
 
       subject.dalliance_background_process
+      expect(subject).to be_queued
       Delayed::Worker.new(:queues => [:dalliance]).work_off
       subject.reload
 
@@ -91,6 +95,7 @@ RSpec.describe DallianceModel do
 
       it 'successfully runs the dalliance_reprocess method' do
         subject.dalliance_background_reprocess
+        expect(subject).to be_queued
         Delayed::Worker.new(:queues => [:dalliance]).work_off
         subject.reload
 
@@ -102,6 +107,7 @@ RSpec.describe DallianceModel do
       it 'increases the total processing time counter' do
         original_duration = subject.dalliance_duration
         subject.dalliance_background_reprocess
+        expect(subject).to be_queued
         Delayed::Worker.new(:queues => [:dalliance]).work_off
         subject.reload
 
@@ -128,6 +134,8 @@ RSpec.describe DallianceModel do
 
       it "should NOT call the dalliance_method w/ a Delayed::Worker (different queue)" do
         subject.dalliance_background_process
+        expect(subject).not_to be_queued(queue_name: 'dalliance')
+        expect(subject).to be_queued(queue_name: queue)
         Delayed::Worker.new(:queues => [:dalliance]).work_off
         subject.reload
 

--- a/spec/dalliance/asynchronous_resque_spec.rb
+++ b/spec/dalliance/asynchronous_resque_spec.rb
@@ -97,6 +97,9 @@ RSpec.describe DallianceModel do
 
       it "should NOT call the dalliance_method w/ a Delayed::Worker (different queue)" do
         subject.dalliance_background_process
+
+        expect(subject).to be_queued
+
         Resque::Worker.new(:dalliance).process
         subject.reload
 
@@ -106,6 +109,9 @@ RSpec.describe DallianceModel do
 
       it "should call the dalliance_method w/ a Delayed::Worker (same queue)" do
         subject.dalliance_background_process
+
+        expect(subject).to be_queued
+
         Resque::Worker.new(queue).process
         subject.reload
 
@@ -132,6 +138,9 @@ RSpec.describe DallianceModel do
       Resque::Stat.clear(:failed)
 
       subject.dalliance_background_reprocess
+
+      expect(subject).to be_queued
+
       Resque::Worker.new(:dalliance).process
       subject.reload
 
@@ -141,6 +150,7 @@ RSpec.describe DallianceModel do
         expect(Resque::Stat[:processed]).to eq(1)
         expect(Resque::Stat[:failed]).to eq(0)
         expect(subject.reprocessed_count).to eq(1)
+        expect(subject).not_to be_queued
       end
     end
 


### PR DESCRIPTION
Introspects Resque/ActiveJob to find any queued job that matches the dalliance record being checked.  This doesn't check for *what* dalliance method is queued (eg dalliance_process, dalliance_reprocess), just that any job exists for the record

Example usage:

```ruby
record = SomeDallianceModel.create
record.queued? # => false

record.dalliance_background_process
record.queued? # => true
record.queued?(queue_name: 'some_other_queue') # => false

# after processing finishes
record.queued? # => false
```