### PR TITLE
update depreciated ActiveModel::Errors for Rails 6.1

### DIFF
--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    dalliance (0.8.1)
+    dalliance (0.10.0)
       rails (>= 5.0, < 6.2)
       state_machine
 

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    dalliance (0.8.1)
+    dalliance (0.10.0)
       rails (>= 5.0, < 6.2)
       state_machine
 

--- a/lib/dalliance.rb
+++ b/lib/dalliance.rb
@@ -174,9 +174,16 @@ module Dalliance
   def store_dalliance_validation_error!
     self.dalliance_error_hash = {}
 
-    self.errors.each do |attribute, error|
-      self.dalliance_error_hash[attribute] ||= []
-      self.dalliance_error_hash[attribute] << error
+    if defined?(Rails) && ::Rails::VERSION::MAJOR >= 6 && ::Rails::VERSION::MINOR >= 1
+      self.errors.each do |error|
+        self.dalliance_error_hash[error.attribute] ||= []
+        self.dalliance_error_hash[error.attribute] << error.message
+      end
+    else
+      self.errors.each do |attribute, error|
+        self.dalliance_error_hash[attribute] ||= []
+        self.dalliance_error_hash[attribute] << error
+      end
     end
 
     begin


### PR DESCRIPTION
```
DEPRECATION WARNING: Enumerating ActiveModel::Errors as a hash has been deprecated.
In Rails 6.1, `errors` is an array of Error objects,
therefore it should be accessed by a block with a single block
parameter like this:

person.errors.each do |error|
  attribute = error.attribute
  message = error.message
end
```